### PR TITLE
chore: update PiTrac upstream URL to PiTracLM/PiTrac

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 # Notice
 
-LaunchTrac is a derivative work based on [PiTrac](https://github.com/jeshernandez/PiTrac), the open-source golf launch monitor created by James Pilgrim and contributors at Verdant Consultants, LLC.
+LaunchTrac is a derivative work based on [PiTrac](https://github.com/PiTracLM/PiTrac), the open-source golf launch monitor created by James Pilgrim and contributors at Verdant Consultants, LLC.
 
 LaunchTrac is a ground-up rewrite in Rust of the original PiTrac C++ codebase, with a different architecture, hardware approach, and feature set. The core algorithms for ball detection, trajectory calculation, spin estimation, and simulator protocol integration are derived from PiTrac's implementations.
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ This is an early-stage rewrite. The pipeline works end-to-end on synthetic data.
 
 ## Acknowledgments
 
-Inspired by [PiTrac](https://github.com/jeshernandez/PiTrac), the world's first fully open-source DIY golf launch monitor.
+Inspired by [PiTrac](https://github.com/PiTracLM/PiTrac), the world's first fully open-source DIY golf launch monitor.
 
 ## Attribution
 
-LaunchTrac is a derivative work of [PiTrac](https://github.com/jeshernandez/PiTrac), the world's first fully open-source DIY golf launch monitor, created by James Pilgrim and contributors at Verdant Consultants, LLC. See [NOTICE.md](NOTICE.md) for details.
+LaunchTrac is a derivative work of [PiTrac](https://github.com/PiTracLM/PiTrac), the world's first fully open-source DIY golf launch monitor, created by James Pilgrim and contributors at Verdant Consultants, LLC. See [NOTICE.md](NOTICE.md) for details.
 
 ## License
 

--- a/crates/launchtrac-api/src/lib.rs
+++ b/crates/launchtrac-api/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-auth/src/lib.rs
+++ b/crates/launchtrac-auth/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-common/src/config.rs
+++ b/crates/launchtrac-common/src/config.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use serde::{Deserialize, Serialize};

--- a/crates/launchtrac-common/src/error.rs
+++ b/crates/launchtrac-common/src/error.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use thiserror::Error;

--- a/crates/launchtrac-common/src/lib.rs
+++ b/crates/launchtrac-common/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 pub mod config;

--- a/crates/launchtrac-common/src/shot.rs
+++ b/crates/launchtrac-common/src/shot.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use chrono::{DateTime, Utc};

--- a/crates/launchtrac-common/src/types.rs
+++ b/crates/launchtrac-common/src/types.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use serde::{Deserialize, Serialize};

--- a/crates/launchtrac-companion/src/lib.rs
+++ b/crates/launchtrac-companion/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-edge/examples/generate_fixtures.rs
+++ b/crates/launchtrac-edge/examples/generate_fixtures.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 /// Synthetic test fixture generator for LaunchTrac v2.

--- a/crates/launchtrac-edge/examples/process_fixture.rs
+++ b/crates/launchtrac-edge/examples/process_fixture.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 /// Process a fixture through the full LaunchTrac vision pipeline.

--- a/crates/launchtrac-edge/src/actors/camera1.rs
+++ b/crates/launchtrac-edge/src/actors/camera1.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_hal::mock::MockHardware;

--- a/crates/launchtrac-edge/src/actors/cloud_uploader.rs
+++ b/crates/launchtrac-edge/src/actors/cloud_uploader.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 /// Cloud uploader actor -- sends shot data to LaunchTrac cloud for storage and analytics.

--- a/crates/launchtrac-edge/src/actors/image_processor.rs
+++ b/crates/launchtrac-edge/src/actors/image_processor.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::shot::ShotData;

--- a/crates/launchtrac-edge/src/actors/mod.rs
+++ b/crates/launchtrac-edge/src/actors/mod.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 pub mod camera1;

--- a/crates/launchtrac-edge/src/actors/motion_detector.rs
+++ b/crates/launchtrac-edge/src/actors/motion_detector.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_hal::ImageFrame;

--- a/crates/launchtrac-edge/src/actors/results_router.rs
+++ b/crates/launchtrac-edge/src/actors/results_router.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::config::Config;

--- a/crates/launchtrac-edge/src/actors/strobe_controller.rs
+++ b/crates/launchtrac-edge/src/actors/strobe_controller.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::config::Config;

--- a/crates/launchtrac-edge/src/main.rs
+++ b/crates/launchtrac-edge/src/main.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 mod actors;

--- a/crates/launchtrac-edge/src/web/mod.rs
+++ b/crates/launchtrac-edge/src/web/mod.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-hal/src/camera.rs
+++ b/crates/launchtrac-hal/src/camera.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-hal/src/gpio.rs
+++ b/crates/launchtrac-hal/src/gpio.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-hal/src/lib.rs
+++ b/crates/launchtrac-hal/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 pub mod camera;

--- a/crates/launchtrac-hal/src/mock.rs
+++ b/crates/launchtrac-hal/src/mock.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use std::path::PathBuf;

--- a/crates/launchtrac-hal/src/pwm.rs
+++ b/crates/launchtrac-hal/src/pwm.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-ota/src/lib.rs
+++ b/crates/launchtrac-ota/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-relay/src/lib.rs
+++ b/crates/launchtrac-relay/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-shot/src/lib.rs
+++ b/crates/launchtrac-shot/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use axum::Router;

--- a/crates/launchtrac-sim-proto/src/e6.rs
+++ b/crates/launchtrac-sim-proto/src/e6.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use serde::{Deserialize, Serialize};

--- a/crates/launchtrac-sim-proto/src/gspro.rs
+++ b/crates/launchtrac-sim-proto/src/gspro.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use serde::{Deserialize, Serialize};

--- a/crates/launchtrac-sim-proto/src/lib.rs
+++ b/crates/launchtrac-sim-proto/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 pub mod e6;

--- a/crates/launchtrac-vision/src/ball_detector.rs
+++ b/crates/launchtrac-vision/src/ball_detector.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-vision/src/calibration.rs
+++ b/crates/launchtrac-vision/src/calibration.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-vision/src/lib.rs
+++ b/crates/launchtrac-vision/src/lib.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 pub mod ball_detector;

--- a/crates/launchtrac-vision/src/spin_estimator.rs
+++ b/crates/launchtrac-vision/src/spin_estimator.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-vision/src/trajectory.rs
+++ b/crates/launchtrac-vision/src/trajectory.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 use launchtrac_common::error::LaunchTracError;

--- a/crates/launchtrac-vision/tests/integration_test.rs
+++ b/crates/launchtrac-vision/tests/integration_test.rs
@@ -4,7 +4,7 @@
 // Copyright (C) 2026, LaunchTrac contributors
 //
 // This file is part of LaunchTrac, a derivative work of PiTrac
-// (https://github.com/jeshernandez/PiTrac). Both projects are licensed
+// (https://github.com/PiTracLM/PiTrac). Both projects are licensed
 // under the GNU General Public License v2.0.
 //
 /// End-to-end integration test for the LaunchTrac vision pipeline.


### PR DESCRIPTION
## Summary
- James Pilgrim asked us to point at the canonical PiTrac repo (`github.com/PiTracLM/PiTrac`) instead of the older `jeshernandez/PiTrac` fork, which was an early-contributor mirror.
- Updates `NOTICE.md`, `README.md`, and the SPDX/attribution header on all 36 Rust source files.

## Test plan
- [ ] CI green (lint, test, dashboard build)
- [ ] Spot-check NOTICE.md and README.md render correctly on GitHub